### PR TITLE
Implement double-ended iterators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ EXAMPLES = \
 	inspect \
 	skip_take_while \
 	zip \
-	reverse
+	reverse \
+	double_ended
 EXAMPLES_BIN = $(addprefix examples/,$(EXAMPLES))
 
 STATICLIB = lib$(NAME).a

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ EXAMPLES = \
 	sum \
 	inspect \
 	skip_take_while \
-	zip
+	zip \
+	over_array_back
 EXAMPLES_BIN = $(addprefix examples/,$(EXAMPLES))
 
 STATICLIB = lib$(NAME).a

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ MODULES = \
 	chunked \
 	collect \
 	inspect \
-	zip
+	zip \
+	reverse
 
 EXAMPLES = \
 	repeat_take \
@@ -54,7 +55,7 @@ EXAMPLES = \
 	inspect \
 	skip_take_while \
 	zip \
-	over_array_back
+	reverse
 EXAMPLES_BIN = $(addprefix examples/,$(EXAMPLES))
 
 STATICLIB = lib$(NAME).a

--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ All iterators and functions below are prefixed with the name `citer_` to avoid c
 | next       | Returns the next item of the iterator.                                                |
 | next_back  | Returns the next item from the back of a double-ended iterator.                       |
 | nth        | Returns the Nth item of an iterator.                                                  |
+| nth_back   | Returns the Nth item from the end of a double-ended iterator.                         |

--- a/README.md
+++ b/README.md
@@ -144,11 +144,14 @@ which still doesn't require much code.
 
 The `iterator_t` type is defined as follows:
 ```c
+typedef void *(*citer_next_fn)(void *);
+typedef void (*citer_free_data_fn)(void *);
+
 typedef struct iterator_t {
     void *data;
-    void *(*next)(void *data);
-    void *(*next_back)(void *data);
-    void (*free_data)(void *data);
+	citer_next_fn next;
+	citer_next_fn next_back;
+	citer_free_data_fn free_data;
 } iterator_t;
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ because the 5th was already returned by a call to `citer_next_back()`.
 
 An iterator is very easy to implement.
 Take a look in any of the files in the `src/` directory to see how they are implemented.
-`repeat.c` is especially simple, and `map.c` is a good example of a very powerful iterator
-which still doesn't require much code.
+`repeat.c` is especially simple,
+and `citer_map()` in `map.c` is a good example of a very powerful iterator which still doesn't require much code.
 
 The `iterator_t` type is defined as follows:
 ```c

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ All iterators and functions below are prefixed with the name `citer_` to avoid c
 | fold       | Accumulate all items of an iterator into a single value using a given function.       |
 | free       | Frees (de-allocates) an iterator and its associated data.                             |
 | free_data  | Frees the data associated with an iterator, but not the iterator structure itself.    |
+| is_double_ended | Checks if an iterator is double-ended.                                           |
 | max        | Returns the maximum item of an iterator, comparing using a given comparison function. |
 | min        | Returns the minimum item of an iterator, comparing using a given comparison function. |
 | next       | Returns the next item of the iterator.                                                |
+| next_back  | Returns the next item from the back of a double-ended iterator.                       |
 | nth        | Returns the Nth item of an iterator.                                                  |

--- a/examples/double_ended.c
+++ b/examples/double_ended.c
@@ -1,0 +1,75 @@
+/*
+ * CIter - C library for lazily-evaluated iterators.
+ * Copyright (C) 2024  Kian Kasad <kian@kasad.com>
+ *
+ * This file is part of CIter.
+ *
+ * CIter is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, version 3 of the License.
+ *
+ * CIter is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with CIter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <citer.h>
+
+#define UNUSED(x) ((void) (x))
+
+static void *map_deref(void *item) {
+    return *((void **) item);
+}
+
+static bool is_even(void *item, void *fn_data) {
+    UNUSED(fn_data);
+    return ((unsigned long) item) % 2 == 0;
+}
+
+static void print_item(void *item, void *fn_data) {
+    printf("%s: %lu\n", (const char *) fn_data, (unsigned long) item);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        return 1;
+    }
+
+    unsigned long arr[] = { 1, 2, 3, 4, 5 };
+    iterator_t *it;
+
+    /*
+     * Double-ended iterators which must be tested:
+     * - [x] over_array
+     * - [ ] repeat (but we can't test this without take)
+     * - [x] chain
+     * - [x] filter
+     * - [x] map
+     * - [x] once
+     * - [x] flatten
+     * - [x] inspect
+     * - [x] reverse
+     */
+
+    it = citer_over_array(arr, sizeof(*arr), sizeof(arr) / sizeof(*arr));
+    it = citer_map(it, map_deref);
+    it = citer_chain(it, citer_flatten(citer_once(citer_once((void *) 6ul))));
+    it = citer_inspect(it, print_item, "Before map");
+    it = citer_filter(it, is_even, NULL);
+    it = citer_reverse(it);
+
+    void *item;
+    while ((item = citer_next(it)))
+        printf("Got: %lu\n", (unsigned long) item);
+
+    citer_free(it);
+
+    return 0;
+}

--- a/examples/over_array_back.c
+++ b/examples/over_array_back.c
@@ -1,0 +1,42 @@
+/*
+ * CIter - C library for lazily-evaluated iterators.
+ * Copyright (C) 2024  Kian Kasad <kian@kasad.com>
+ *
+ * This file is part of CIter.
+ *
+ * CIter is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, version 3 of the License.
+ *
+ * CIter is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with CIter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+#include <citer.h>
+
+int main(int argc, char *argv[]) {
+	if (argc <= 1) {
+		fprintf(stderr, "Usage: %s <args...>\n", argv[0]);
+		return 1;
+	}
+
+	iterator_t *it = citer_over_array((void **) argv + 1, sizeof(*argv), argc - 1);
+
+	char **itemptr;
+	unsigned long count = 0;
+	while ((itemptr = (char **) citer_next_back(it))) {
+		printf("Got: %s\n", *itemptr);
+		count++;
+	}
+	printf("Count: %lu\n", count);
+
+	citer_free(it);
+
+	return 0;
+}

--- a/examples/reverse.c
+++ b/examples/reverse.c
@@ -26,11 +26,11 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	iterator_t *it = citer_over_array((void **) argv + 1, sizeof(*argv), argc - 1);
+	iterator_t *it = citer_reverse(citer_over_array((void **) argv + 1, sizeof(*argv), argc - 1));
 
 	char **itemptr;
 	unsigned long count = 0;
-	while ((itemptr = (char **) citer_next_back(it))) {
+	while ((itemptr = (char **) citer_next(it))) {
 		printf("Got: %s\n", *itemptr);
 		count++;
 	}

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -41,4 +41,4 @@ run ./count_using_fold {a..z}
 run ./sum {1..5}
 run ./inspect {1..5}
 run ./skip_take_while {1..100}
-run ./over_array_back {a..f}
+run ./reverse {a..f}

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -41,3 +41,4 @@ run ./count_using_fold {a..z}
 run ./sum {1..5}
 run ./inspect {1..5}
 run ./skip_take_while {1..100}
+run ./over_array_back {a..f}

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -43,3 +43,4 @@ run ./inspect {1..5}
 run ./skip_take_while {1..100}
 run ./zip {1..5} {a..e}
 run ./reverse {a..f}
+run ./double_ended

--- a/src/chain.c
+++ b/src/chain.c
@@ -34,6 +34,15 @@ static void *citer_chain_next(void *_data) {
 		return citer_next(data->second);
 }
 
+static void *citer_chain_next_back(void *_data) {
+	citer_chain_data_t *data = (citer_chain_data_t *) _data;;
+	void *item;
+	if ((item = citer_next_back(data->second)))
+		return item;
+	else
+		return citer_next_back(data->first);
+}
+
 static void citer_chain_free_data(void *_data) {
 	citer_chain_data_t *data = (citer_chain_data_t *) _data;
 	citer_free(data->first);
@@ -54,5 +63,10 @@ iterator_t *citer_chain(iterator_t *first, iterator_t *second) {
 		.next_back = NULL,
 		.free_data = citer_chain_free_data,
 	};
+
+	/* Make chain double-ended if both inputs are. */
+	if (first->next_back && second->next_back)
+		it->next_back = citer_chain_next_back;
+
 	return it;
 }

--- a/src/chain.c
+++ b/src/chain.c
@@ -51,6 +51,7 @@ iterator_t *citer_chain(iterator_t *first, iterator_t *second) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_chain_next,
+		.next_back = NULL,
 		.free_data = citer_chain_free_data,
 	};
 	return it;

--- a/src/chunked.c
+++ b/src/chunked.c
@@ -60,6 +60,7 @@ iterator_t *citer_chunked(iterator_t *orig, size_t chunksize) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_chunked_next,
+        .next_back = NULL,
         .free_data = citer_chunked_free_data,
     };
     return it;

--- a/src/chunked.c
+++ b/src/chunked.c
@@ -40,6 +40,21 @@ static void *citer_chunked_next(void *_data) {
     return chunk;
 }
 
+static void *citer_chunked_next_back(void *_data) {
+    citer_chunked_data_t *data = (citer_chunked_data_t *) _data;
+
+    void *first = citer_next_back(data->orig);
+    if (!first)
+        return NULL;
+
+    void **chunk = malloc(data->chunksize * sizeof(*chunk));
+    chunk[0] = first;
+    for (size_t i = 1; i < data->chunksize; i++) {
+        chunk[i] = citer_next_back(data->orig);
+    }
+    return chunk;
+}
+
 static void citer_chunked_free_data(void *_data) {
     citer_chunked_data_t *data = (citer_chunked_data_t *) _data;
     citer_free(data->orig);
@@ -60,7 +75,7 @@ iterator_t *citer_chunked(iterator_t *orig, size_t chunksize) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_chunked_next,
-        .next_back = NULL,
+        .next_back = citer_is_double_ended(orig) ? citer_chunked_next_back : NULL,
         .free_data = citer_chunked_free_data,
     };
     return it;

--- a/src/chunked.c
+++ b/src/chunked.c
@@ -20,6 +20,8 @@
 
 #include <stdlib.h>
 
+/* TODO: Once size reporting is implemented, make chunked double-ended. */
+
 typedef struct citer_chunked_data {
     iterator_t *orig;
     size_t chunksize;
@@ -36,21 +38,6 @@ static void *citer_chunked_next(void *_data) {
     chunk[0] = first;
     for (size_t i = 1; i < data->chunksize; i++) {
         chunk[i] = citer_next(data->orig);
-    }
-    return chunk;
-}
-
-static void *citer_chunked_next_back(void *_data) {
-    citer_chunked_data_t *data = (citer_chunked_data_t *) _data;
-
-    void *first = citer_next_back(data->orig);
-    if (!first)
-        return NULL;
-
-    void **chunk = malloc(data->chunksize * sizeof(*chunk));
-    chunk[0] = first;
-    for (size_t i = 1; i < data->chunksize; i++) {
-        chunk[i] = citer_next_back(data->orig);
     }
     return chunk;
 }
@@ -75,7 +62,7 @@ iterator_t *citer_chunked(iterator_t *orig, size_t chunksize) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_chunked_next,
-        .next_back = citer_is_double_ended(orig) ? citer_chunked_next_back : NULL,
+        .next_back = NULL,
         .free_data = citer_chunked_free_data,
     };
     return it;

--- a/src/enumerate.c
+++ b/src/enumerate.c
@@ -54,6 +54,7 @@ iterator_t *citer_enumerate(iterator_t *orig) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_enumerate_next,
+        .next_back = NULL,
         .free_data = citer_enumerate_free_data,
     };
     return it;

--- a/src/enumerate.c
+++ b/src/enumerate.c
@@ -20,6 +20,8 @@
 
 #include <stdlib.h>
 
+/* TODO: Once length reporting is implemented, make enumerate double-ended. */
+
 typedef struct citer_enumerate_data {
     iterator_t *orig;
     size_t index;

--- a/src/filters.c
+++ b/src/filters.c
@@ -83,6 +83,16 @@ static void *citer_filter_next(void *_data) {
     return NULL;
 }
 
+static void *citer_filter_next_back(void *_data) {
+    citer_filter_data_t *data = (citer_filter_data_t *) _data;
+    void *item;
+    while ((item = citer_next_back(data->orig))) {
+        if (data->predicate(item, data->predicate_data))
+            return item;
+    }
+    return NULL;
+}
+
 static void citer_filter_free_data(void *_data) {
     citer_filter_data_t *data = (citer_filter_data_t *) _data;
     citer_free(data->orig);
@@ -100,7 +110,7 @@ iterator_t *citer_filter(iterator_t *orig, citer_predicate_t predicate, void *ex
     *it = (iterator_t) {
         .data = data,
         .next = citer_filter_next,
-        .next_back = NULL,
+        .next_back = citer_is_double_ended(orig) ? citer_filter_next_back : NULL,
         .free_data = citer_filter_free_data,
     };
     return it;

--- a/src/filters.c
+++ b/src/filters.c
@@ -100,6 +100,7 @@ iterator_t *citer_filter(iterator_t *orig, citer_predicate_t predicate, void *ex
     *it = (iterator_t) {
         .data = data,
         .next = citer_filter_next,
+        .next_back = NULL,
         .free_data = citer_filter_free_data,
     };
     return it;

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -50,6 +50,7 @@ iterator_t *citer_inspect(iterator_t *orig, citer_inspect_fn_t fn, void *fn_data
     *it = (iterator_t) {
         .data = data,
         .next = citer_inspect_next,
+        .next_back = NULL,
         .free_data = citer_inspect_free_data
     };
     return it;

--- a/src/inspect.c
+++ b/src/inspect.c
@@ -33,6 +33,13 @@ static void *citer_inspect_next(void *_data) {
     return item;
 }
 
+static void *citer_inspect_next_back(void *_data) {
+    citer_inspect_data_t *data = (citer_inspect_data_t *) _data;
+    void *item = citer_next_back(data->orig);
+    data->fn(item, data->fn_data);
+    return item;
+}
+
 static void citer_inspect_free_data(void *_data) {
     citer_inspect_data_t *data = (citer_inspect_data_t *) _data;
     citer_free(data->orig);
@@ -50,7 +57,7 @@ iterator_t *citer_inspect(iterator_t *orig, citer_inspect_fn_t fn, void *fn_data
     *it = (iterator_t) {
         .data = data,
         .next = citer_inspect_next,
-        .next_back = NULL,
+        .next_back = citer_is_double_ended(orig) ? citer_inspect_next_back : NULL,
         .free_data = citer_inspect_free_data
     };
     return it;

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -56,15 +56,6 @@ void citer_free(iterator_t *it) {
 }
 
 /*
- * Check if an iterator is double-ended.
- *
- * Returns true (1) if the iterator is double-ended, false (0) otherwise.
- */
-bool citer_is_double_ended(iterator_t *it) {
-	return it->next_back != NULL;
-}
-
-/*
  * Count the number of items in an iterator.
  *
  * Only works for finite iterators. Calling this function on an infinite

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -18,6 +18,7 @@
 
 #include "iterator.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 /*
@@ -25,6 +26,17 @@
  */
 void *citer_next(iterator_t *it) {
 	return it->next(it->data);
+}
+
+/*
+ * Get the next item from the back of a double-ended iterator.
+ */
+void *citer_next_back(iterator_t *it) {
+	if (it->next_back)
+		return it->next_back(it->data);
+	else
+		/* TODO: Notify caller of error. */
+		return NULL;
 }
 
 /*
@@ -41,6 +53,15 @@ void citer_free_data(iterator_t *it) {
 void citer_free(iterator_t *it) {
 	citer_free_data(it);
 	free(it);
+}
+
+/*
+ * Check if an iterator is double-ended.
+ *
+ * Returns true (1) if the iterator is double-ended, false (0) otherwise.
+ */
+bool citer_is_double_ended(iterator_t *it) {
+	return it->next_back != NULL;
 }
 
 /*

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -19,6 +19,7 @@
 #ifndef _CITER_ITERATOR_H_
 #define _CITER_ITERATOR_H_
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /*
@@ -27,11 +28,17 @@
  * Fields:
  *   data - Opaque data for this iterator_t
  *   next - A method that takes a pointer to this iterator_t's data and returns
- *          the next item
+ *          the next item.
+ *   next_back - A method that takes a pointer to this iterator_t's data and
+ *               returns the next item from the back of the iterator. This
+ *               field is NULL for iterators which are not double-ended.
+ *   free_data - A method that takes a pointer to this iterator_t's data and
+ *               frees (de-allocates) said data.
  */
 typedef struct iterator_t {
 	void *data;
 	void *(*next)(void *data);
+	void *(*next_back)(void *data);
 	void (*free_data)(void *data);
 } iterator_t;
 
@@ -39,6 +46,11 @@ typedef struct iterator_t {
  * Get the next item from an iterator.
  */
 void *citer_next(iterator_t *);
+
+/*
+ * Get the next item from the back of a double-ended iterator.
+ */
+void *citer_next_back(iterator_t *);
 
 /*
  * Free an iterator's data
@@ -49,6 +61,13 @@ void citer_free_data(iterator_t *);
  * Free a heap-allocated iterator.
  */
 void citer_free(iterator_t *);
+
+/*
+ * Check if an iterator is double-ended.
+ *
+ * Returns 1 if the iterator is double-ended, 0 otherwise.
+ */
+bool citer_is_double_ended(iterator_t *);
 
 /*
  * Count the number of items in an iterator.

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -67,7 +67,7 @@ void citer_free(iterator_t *);
  *
  * Returns 1 if the iterator is double-ended, 0 otherwise.
  */
-bool citer_is_double_ended(iterator_t *);
+#define citer_is_double_ended(it) (!!(it)->next_back)
 
 /*
  * Count the number of items in an iterator.

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -23,6 +23,18 @@
 #include <stddef.h>
 
 /*
+ * Function type for getting the next item from an iterator.
+ * Used for both iterator_t::next() and iterator_t::next_back().
+ */
+typedef void *(*citer_next_fn)(void *);
+
+/*
+ * Function type for freeing an iterator's data.
+ * Used for iterator_t::free_data().
+ */
+typedef void (*citer_free_data_fn)(void *);
+
+/*
  * Iterator structure
  *
  * Fields:
@@ -37,9 +49,9 @@
  */
 typedef struct iterator_t {
 	void *data;
-	void *(*next)(void *data);
-	void *(*next_back)(void *data);
-	void (*free_data)(void *data);
+	citer_next_fn next;
+	citer_next_fn next_back;
+	citer_free_data_fn free_data;
 } iterator_t;
 
 /*

--- a/src/map.c
+++ b/src/map.c
@@ -45,6 +45,7 @@ iterator_t *citer_map(iterator_t *orig, citer_map_fn_t fn) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_map_next,
+        .next_back = NULL,
         .free_data = citer_map_free_data
     };
     return it;
@@ -95,6 +96,7 @@ iterator_t *citer_flatten(iterator_t *orig) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_flatten_next,
+        .next_back = NULL,
         .free_data = citer_flatten_free_data,
     };
     return it;

--- a/src/map.c
+++ b/src/map.c
@@ -61,10 +61,10 @@ iterator_t *citer_flat_map(iterator_t *orig, citer_flat_map_fn_t fn) {
     return citer_flatten(citer_map(orig, (citer_map_fn_t) fn));
 }
 
-/* FIXME: Make flatten double-ended */
 typedef struct citer_flatten_data {
     iterator_t *orig;
     iterator_t *cur;
+    iterator_t *cur_back;
 } citer_flatten_data_t;
 
 void *citer_flatten_next(void *_data) {
@@ -72,14 +72,42 @@ void *citer_flatten_next(void *_data) {
     void *item = NULL;
     while (!item) {
         if (data->cur) {
-            void *item = citer_next(data->cur);
+            item = citer_next(data->cur);
             if (!item) {
                 citer_free(data->cur);
                 data->cur = NULL;
             }
-        }
-        if (!data->cur) {
+        } else {
             data->cur = citer_next(data->orig);
+            if (!data->cur) {
+                if (data->cur_back)
+                    data->cur = data->cur_back;
+                else
+                    break;
+            }
+        }
+    }
+    return item;
+}
+
+void *citer_flatten_next_back(void *_data) {
+    citer_flatten_data_t *data = (citer_flatten_data_t *) _data;
+    void *item = NULL;
+    while (!item) {
+        if (data->cur_back) {
+            item = citer_next_back(data->cur_back);
+            if (!item) {
+                citer_free(data->cur_back);
+                data->cur_back = NULL;
+            }
+        } else {
+            data->cur_back = citer_next_back(data->orig);
+            if (!data->cur_back) {
+                if (data->cur)
+                    data->cur_back = data->cur;
+                else
+                    break;
+            }
         }
     }
     return item;
@@ -89,6 +117,8 @@ void citer_flatten_free_data(void *_data) {
     citer_flatten_data_t *data = (citer_flatten_data_t *) _data;
     if (data->cur)
         citer_free(data->cur);
+    if (data->cur_back && (data->cur_back != data->cur))
+        citer_free(data->cur_back);
     citer_free(data->orig);
     free(data);
 }
@@ -103,7 +133,7 @@ iterator_t *citer_flatten(iterator_t *orig) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_flatten_next,
-        .next_back = NULL,
+        .next_back = citer_is_double_ended(orig) ? citer_flatten_next_back : NULL,
         .free_data = citer_flatten_free_data,
     };
     return it;

--- a/src/map.c
+++ b/src/map.c
@@ -32,6 +32,12 @@ static void *citer_map_next(void *_data) {
     return next ? data->fn(next) : NULL;
 }
 
+static void *citer_map_next_back(void *_data) {
+    citer_map_data_t *data = (citer_map_data_t *) _data;
+    void *next = citer_next_back(data->orig);
+    return next ? data->fn(next) : NULL;
+}
+
 static void citer_map_free_data(void *_data) {
     citer_map_data_t *data = (citer_map_data_t *) _data;
     citer_free(data->orig);
@@ -45,7 +51,7 @@ iterator_t *citer_map(iterator_t *orig, citer_map_fn_t fn) {
     *it = (iterator_t) {
         .data = data,
         .next = citer_map_next,
-        .next_back = NULL,
+        .next_back = citer_is_double_ended(orig) ? citer_map_next_back : NULL,
         .free_data = citer_map_free_data
     };
     return it;
@@ -55,6 +61,7 @@ iterator_t *citer_flat_map(iterator_t *orig, citer_flat_map_fn_t fn) {
     return citer_flatten(citer_map(orig, (citer_map_fn_t) fn));
 }
 
+/* FIXME: Make flatten double-ended */
 typedef struct citer_flatten_data {
     iterator_t *orig;
     iterator_t *cur;

--- a/src/over_array.c
+++ b/src/over_array.c
@@ -54,6 +54,7 @@ iterator_t *citer_over_array(void *array, size_t itemsize, size_t len) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_over_array_next,
+		.next_back = NULL,
 		.free_data = citer_over_array_free_data,
 	};
 	return it;

--- a/src/over_array.c
+++ b/src/over_array.c
@@ -37,6 +37,16 @@ static void *citer_over_array_next(void *_data) {
 	}
 }
 
+static void *citer_over_array_next_back(void *_data) {
+	citer_over_array_data_t *data = (citer_over_array_data_t *) _data;
+	if (data->i < data->len) {
+		/* Cast to (char *) so pointer arithmetic is in terms of bytes. */
+		return (void *) (((char *) data->array) + (((data->len--) - 1) * data->itemsize));
+	} else {
+		return NULL;
+	}
+}
+
 void citer_over_array_free_data(void *_data) {
 	free(_data);
 }
@@ -54,7 +64,7 @@ iterator_t *citer_over_array(void *array, size_t itemsize, size_t len) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_over_array_next,
-		.next_back = NULL,
+        .next_back = citer_over_array_next_back,
 		.free_data = citer_over_array_free_data,
 	};
 	return it;

--- a/src/repeat.c
+++ b/src/repeat.c
@@ -33,7 +33,7 @@ iterator_t *citer_repeat(void *item) {
 	*it = (iterator_t) {
 		.data = item,
 		.next = citer_repeat_next,
-		.next_back = NULL,
+		.next_back = citer_repeat_next,
 		.free_data = citer_repeat_free_data,
 	};
 	return it;

--- a/src/repeat.c
+++ b/src/repeat.c
@@ -38,3 +38,32 @@ iterator_t *citer_repeat(void *item) {
 	};
 	return it;
 }
+
+/* We must use a struct so we can change the value of the item pointer from the
+ * next(_back)? function. */
+typedef struct citer_once_data {
+	void *item;
+} citer_once_data_t;
+
+static void *citer_once_next(void *_data) {
+	citer_once_data_t *data = (citer_once_data_t *) _data;
+	void *item = NULL;
+	if (data->item) {
+		item = data->item;
+		data->item = NULL;
+	}
+	return item;
+}
+
+iterator_t *citer_once(void *item) {
+	citer_once_data_t *data = malloc(sizeof(*data));
+	data->item = item;
+	iterator_t *it = malloc(sizeof(*it));
+	*it = (iterator_t) {
+		.data = data,
+		.next = citer_once_next,
+		.next_back = citer_once_next,
+		.free_data = free,
+	};
+	return it;
+}

--- a/src/repeat.c
+++ b/src/repeat.c
@@ -29,11 +29,12 @@ static void citer_repeat_free_data(void *data) {
 }
 
 iterator_t *citer_repeat(void *item) {
-	iterator_t *repeat = malloc(sizeof(*repeat));
-	*repeat = (iterator_t) {
+	iterator_t *it = malloc(sizeof(*it));
+	*it = (iterator_t) {
 		.data = item,
 		.next = citer_repeat_next,
+		.next_back = NULL,
 		.free_data = citer_repeat_free_data,
 	};
-	return repeat;
+	return it;
 }

--- a/src/repeat.h
+++ b/src/repeat.h
@@ -31,6 +31,6 @@ iterator_t *citer_repeat(void *);
  *
  * The returned iterator must be freed after use with citer_free().
  */
-#define citer_once(item) citer_take(citer_repeat(item), 1)
+iterator_t *citer_once(void *);
 
 #endif /* _CITER_REPEAT_H_ */

--- a/src/reverse.c
+++ b/src/reverse.c
@@ -1,0 +1,40 @@
+/*
+ * CIter - C library for lazily-evaluated iterators.
+ * Copyright (C) 2024  Kian Kasad <kian@kasad.com>
+ *
+ * This file is part of CIter.
+ *
+ * CIter is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, version 3 of the License.
+ *
+ * CIter is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with CIter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "reverse.h"
+
+#include <stdlib.h>
+
+typedef void *(*citer_next_fn_t)(void *);
+typedef void (*citer_free_data_fn_t)(void *);
+
+iterator_t *citer_reverse(iterator_t *orig) {
+    if (!citer_is_double_ended(orig))
+        return NULL;
+
+    /* Since we don't need to store extra data, we can just use the iterator as
+     * the data and use the normal next, next_back, and free functions. */
+    iterator_t *it = malloc(sizeof(*it));
+    *it = (iterator_t) {
+        .data = orig,
+        .next = (citer_next_fn_t) citer_next_back,
+        .next_back = (citer_next_fn_t) citer_next,
+        .free_data = (citer_free_data_fn_t) citer_free,
+    };
+    return it;
+}

--- a/src/reverse.c
+++ b/src/reverse.c
@@ -20,9 +20,6 @@
 
 #include <stdlib.h>
 
-typedef void *(*citer_next_fn_t)(void *);
-typedef void (*citer_free_data_fn_t)(void *);
-
 iterator_t *citer_reverse(iterator_t *orig) {
     if (!citer_is_double_ended(orig))
         return NULL;
@@ -32,9 +29,9 @@ iterator_t *citer_reverse(iterator_t *orig) {
     iterator_t *it = malloc(sizeof(*it));
     *it = (iterator_t) {
         .data = orig,
-        .next = (citer_next_fn_t) citer_next_back,
-        .next_back = (citer_next_fn_t) citer_next,
-        .free_data = (citer_free_data_fn_t) citer_free,
+        .next = (citer_next_fn) citer_next_back,
+        .next_back = (citer_next_fn) citer_next,
+        .free_data = (citer_free_data_fn) citer_free,
     };
     return it;
 }

--- a/src/reverse.h
+++ b/src/reverse.h
@@ -1,0 +1,40 @@
+/*
+ * CIter - C library for lazily-evaluated iterators.
+ * Copyright (C) 2024  Kian Kasad <kian@kasad.com>
+ *
+ * This file is part of CIter.
+ *
+ * CIter is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, version 3 of the License.
+ *
+ * CIter is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with CIter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CITER_REVERSE_H_
+#define _CITER_REVERSE_H_
+
+#include <stddef.h>
+
+#include "iterator.h"
+
+/*
+ * Reverse a double-ended iterator.
+ *
+ * Returns a new iterator which iterates over the items of the input iterator in
+ * reverse.
+ *
+ * The input iterator must be double-ended. If it is not, this function will
+ * return NULL.
+ *
+ * The returned iterator must be freed after use with citer_free(). Doing so
+ * also frees the input iterator.
+ */
+iterator_t *citer_reverse(iterator_t *);
+
+#endif /* _CITER_REVERSE_H_ */

--- a/src/take.c
+++ b/src/take.c
@@ -21,6 +21,8 @@
 
 #include <stdlib.h>
 
+/* TODO: Once size reporting is implemented, make take double-ended. */
+
 typedef struct citer_take_data {
 	iterator_t *original;
 	size_t count;
@@ -67,6 +69,19 @@ static void *citer_skip_next(void *_data) {
 	return citer_next(data->original);
 }
 
+/* TODO: Once size reporting is implemented, make this O(1) for fixed-size
+ * iterators. */
+static void *citer_skip_next_back(void *_data) {
+	citer_take_data_t *data = (citer_take_data_t *) _data;
+	/* Skip items from the front, not the back. */
+	while (data->count > 0) {
+		data->count--;
+		citer_next(data->original);
+	}
+	/* Return the next item from the back. */
+	return citer_next_back(data->original);
+}
+
 iterator_t *citer_skip(iterator_t *original, size_t count) {
 	citer_take_data_t *data = malloc(sizeof(*data));
 	*data = (citer_take_data_t) {
@@ -77,7 +92,7 @@ iterator_t *citer_skip(iterator_t *original, size_t count) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_skip_next,
-        .next_back = NULL,
+        .next_back = citer_is_double_ended(original) ? citer_skip_next_back : NULL,
 		.free_data = citer_take_free_data,
 	};
 	return it;

--- a/src/take.c
+++ b/src/take.c
@@ -52,6 +52,7 @@ iterator_t *citer_take(iterator_t *original, size_t count) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_take_next,
+        .next_back = NULL,
 		.free_data = citer_take_free_data,
 	};
 	return it;
@@ -76,6 +77,7 @@ iterator_t *citer_skip(iterator_t *original, size_t count) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_skip_next,
+        .next_back = NULL,
 		.free_data = citer_take_free_data,
 	};
 	return it;
@@ -129,6 +131,7 @@ iterator_t *citer_take_while(iterator_t *orig, citer_predicate_t predicate, void
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_take_while_next,
+        .next_back = NULL,
 		.free_data = citer_take_while_free_data,
 	};
 	return it;
@@ -162,6 +165,7 @@ iterator_t *citer_skip_while(iterator_t *orig, citer_predicate_t predicate, void
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_skip_while_next,
+        .next_back = NULL,
 		.free_data = citer_take_while_free_data,
 	};
 	return it;

--- a/src/take.c
+++ b/src/take.c
@@ -91,6 +91,18 @@ void *citer_nth(iterator_t *it, size_t n) {
 	return citer_next(it);
 }
 
+void *citer_nth_back(iterator_t *it, size_t n) {
+	/* TODO: Notify caller of error. */
+	if (!citer_is_double_ended(it))
+		return NULL;
+
+	while (n) {
+		citer_next_back(it);
+		n--;
+	}
+	return citer_next_back(it);
+}
+
 typedef struct citer_take_while_data {
 	iterator_t *orig;
 	citer_predicate_t predicate;

--- a/src/take.h
+++ b/src/take.h
@@ -29,6 +29,14 @@ iterator_t *citer_skip(iterator_t *, size_t);
 void *citer_nth(iterator_t *, size_t);
 
 /*
+ * Get the nth item from the back end of a double-ended iterator.
+ *
+ * This function requires a double-ended iterator. If the iterator is not
+ * double-ended, it will return NULL.
+ */
+void *citer_nth_back(iterator_t *, size_t);
+
+/*
  * Take elements from the iterator while the predicate is true.
  *
  * Similar to citer_filter(), but stops when the predicate returns false.

--- a/src/zip.c
+++ b/src/zip.c
@@ -20,6 +20,8 @@
 
 #include <stdlib.h>
 
+/* TODO: Once size reporting is implemented, make zip double-ended. */
+
 typedef struct citer_zip_data {
 	iterator_t *first;
 	iterator_t *second;

--- a/src/zip.c
+++ b/src/zip.c
@@ -59,6 +59,7 @@ iterator_t *citer_zip(iterator_t *first, iterator_t *second) {
 	*it = (iterator_t) {
 		.data = data,
 		.next = citer_zip_next,
+        .next_back = NULL,
 		.free_data = citer_zip_free_data,
 	};
 	return it;


### PR DESCRIPTION
Implements iterators which can be traversed both forwards and backwards.

Tasks:
- [x] Add support for double-ended iterators
- [x] Make source iterators double-ended (e.g. repeat, once, over_array)
- [x] Make transformative iterators double-ended (where possible)
- [x] Document double-ended features in README
- [x] Add tests for double-ended features