### PR TITLE
Return length of collected arrays & linked lists

### DIFF
--- a/examples/collect.c
+++ b/examples/collect.c
@@ -16,6 +16,7 @@
  * with CIter. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -34,7 +35,10 @@ int main(int argc, char *argv[]) {
     }
 
 	iterator_t *it = citer_take(citer_repeat(argv[1]), count);
-    char **arr = (char **) citer_collect_into_array(it);
+
+    size_t len;
+    char **arr = (char **) citer_collect_into_array(it, &len);
+    assert(len == count);
 
     printf("Generated array: [");
     for (unsigned long i = 0; i < count; i++) {

--- a/src/collect.c
+++ b/src/collect.c
@@ -20,7 +20,7 @@
 
 #include <stdlib.h>
 
-void **citer_collect_into_array(iterator_t *it) {
+void **citer_collect_into_array(iterator_t *it, size_t *len_out) {
 #define INITIAL_LEN 10
 
     size_t len = INITIAL_LEN;
@@ -44,12 +44,13 @@ void **citer_collect_into_array(iterator_t *it) {
         res[used++] = item;
     }
 
+    *len_out = used;
     return res;
 
 #undef INITIAL_LEN
 }
 
-citer_llnode_t *citer_collect_into_linked_list(iterator_t *it) {
+citer_llnode_t *citer_collect_into_linked_list(iterator_t *it, citer_llnode_t **tail_out) {
     citer_llnode_t *head = NULL;
     citer_llnode_t *tail = NULL;
 
@@ -78,5 +79,7 @@ citer_llnode_t *citer_collect_into_linked_list(iterator_t *it) {
         }
     }
 
+    if (tail_out)
+        *tail_out = tail;
     return head;
 }

--- a/src/collect.h
+++ b/src/collect.h
@@ -38,12 +38,15 @@ typedef struct citer_llnode {
  * iterator is passed in, this function will loop forever, likely until it runs
  * out of memory for the array.
  *
+ * The second argument to this function is a pointer to a size_t variable that
+ * will be set to the length of the returned array.
+ *
  * The returned array will be dynamically allocated and must be freed after use.
  *
  * This function will consume all items in the iterator, but will not free the
  * iterator.
  */
-void **citer_collect_into_array(iterator_t *);
+void **citer_collect_into_array(iterator_t *, size_t *);
 
 /*
  * Collect items from an iterator into a linked list.
@@ -52,12 +55,16 @@ void **citer_collect_into_array(iterator_t *);
  * iterator is passed in, this function will loop forever, likely until it runs
  * out of memory for the list.
  *
+ * The second argument to this function is a pointer to the location at which to
+ * store the pointer to the tail node in the returned list. If this argument is
+ * NULL, it will not be set.
+ *
  * Each node in the returned list will be dynamically allocated and must be
  * freed after use.
  *
  * This function will consume all items in the iterator, but will not free the
  * iterator.
  */
-citer_llnode_t *citer_collect_into_linked_list(iterator_t *);
+citer_llnode_t *citer_collect_into_linked_list(iterator_t *, citer_llnode_t **);
 
 #endif /* _CITER_COLLECT_H_ */


### PR DESCRIPTION
Adds a parameter to both citer_collect_into_array and citer_collect_into_linked_list.

For the array collector, this parameter is a pointer to a size_t variable in which the length of the returned array is stored.

For the linked list collector, this parameter is a pointer to a pointer to a citer_llnode_t, in which the pointer to the tail of the list is stored.